### PR TITLE
Fixed fasta_gbexport bugs

### DIFF
--- a/lib/fasta.py
+++ b/lib/fasta.py
@@ -389,6 +389,6 @@ class GenbankFastaFile:
                 warnings.warn("Some of your sequences contain dashes (gaps) which is only allowed if you submit them as alignment. If you do not wish to submit your sequences as alignment, please remove the dashes before conversion.")
             # print seqid and attributes
             print('>'+unicifier.unique(name_assembler.name(record)), *
-                  [f"[{field.replace('_', '-')}={record[field].strip()}]" for field in fields if not (field == "seqid" or field == "sequence")], file=file)
+                  [f"[{field.replace('_', '-')}={record[field].strip()}]" for field in fields if record[field] and not record[field].isspace() and not (field == "seqid" or field == "sequence")], file=file)
             # print the sequence
             print(record['sequence'], file=file)


### PR DESCRIPTION
While fixing the 'specimen_voucher' bug, I noticed that there are inconsistencies in usage of '_' and '-' in allowed fasta genbank fields. I looked for a description of this format on the Genbank site and found it in the manual of tbl2asn tool ([list of source modifiers](https://www.ncbi.nlm.nih.gov/Sequin/modifiers.html)). This list consistently uses '-'. So I made the program replace '_' with '-' in the fields' names. 

The problem with 'specimen_voucher' was that it caused an exception that is not shown to a GUI user, so the conversion process crashed silently. Now it should process this field name properly.

Fields with blank content are not printed now.

Closes #9. 