### PR TITLE
Handling of missing 'sequence' column for Tab format

### DIFF
--- a/doc/TAB_FORMAT.md
+++ b/doc/TAB_FORMAT.md
@@ -2,7 +2,7 @@
 A format representing genetic information in tab-separated values form
 
 ## Description
-First line is a tab-separated list of field names. Names 'uniquesequencename' and 'sequence' are required.
+First line is a tab-separated list of field names. A name containing 'sequence' and at least one other name is expected.
 
 Other lines are a tab-separated lists of field values.
 Number of values in a line should be equal to the number of fields' names in the first line.

--- a/lib/tabfile.py
+++ b/lib/tabfile.py
@@ -41,16 +41,26 @@ class Tabfile:
         fields = list(map(str.casefold, fields))
         if 'seqid' not in fields and len(fields) >= 2:
             warnings.warn(
-                "The field 'seqid' is missing. Conversion will proceed, but please check the converted file for correctness.")
+                "The column 'seqid' is missing. Conversion will proceed, but please check the converted file for correctness.")
         if 'sequence' not in fields:
             sequence_candidates = [i for i, field in enumerate(
                 fields) if 'sequence' in field]
             if len(sequence_candidates) == 1:
-                warnings.warn("The field 'sequence' is missing, but another field containing the same term was found and is interpreted as containing the sequences. Conversion will proceed, but please check the converted file for correctness")
+                warnings.warn("The column 'sequence' is missing, but another column header containing the same term was found and is interpreted as containing the sequences. Conversion will proceed, but please check the converted file for correctness")
                 i = sequence_candidates[0]
                 fields[i] = 'sequence'
+            elif len(sequence_candidates) > 1:
+                i = sequence_candidates[0]
+                warnings.warn(
+                    f"The column 'sequence' is missing, the column '{fields[i]}' is interpreted as containing the sequences. Conversion will proceed, but please check the converted file for correctness")
+                fields[i] = 'sequence'
+            else:
+                warnings.warn(
+                    f"The column 'sequence' is missing, the last column '{fields[-1]}' is interpreted as containing the sequences. Conversion will proceed, but please check the converted file for correctness")
+                fields[-1] = 'sequence'
 
         # closure that will iterate over the subsequent lines and yield the records
+
         def record_generator() -> Iterator[Record]:
             for line in file:
                 line = line.rstrip('\n')


### PR DESCRIPTION
This change adds a meaningful warning message for Tab input format, if the column 'sequence' is missing entirely (i.e. there are no column names similar to 'sequence'). In this case the program assumes that the last column is the sequence column and shows a warning message saying this.

Closes #26