### PR TITLE
Support for Tab-no headers format

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Specifying names of the output files:
 
 ## Supported formats
 * `tab`: [Internal tab format][1]
+* `tab_noheaders`: [Internal tab format][1] without headers
 * `fasta`: FASTA format
 * `relaxed_phylip`: relaxed Phylip format
 * `fasta_hapview`: FASTA format for Haplotype Viewer

--- a/doc/TAB_FORMAT.md
+++ b/doc/TAB_FORMAT.md
@@ -8,3 +8,11 @@ Other lines are a tab-separated lists of field values.
 Number of values in a line should be equal to the number of fields' names in the first line.
 A value can be an empty string, but the number of tab symbols in each line should be exactly the same.
 Empty lines are allowed and ignored during reading.
+
+## Variant without the header line
+
+`DNAconvert` uses the first line to detect the sequence column. By default it's the last column. 
+If the last column contains unusual characters, the first column is chosen as the sequence column.
+
+Each line is transformed into a list of non-empty tab-separated strings. The sequence string is yielded unchanged. The other strings are concatenated into the `seqid` value.
+

--- a/lib/formats.py
+++ b/lib/formats.py
@@ -22,6 +22,7 @@ else:
 # formats' names dictionary
 formats: Dict[str, Type[Any]] = dict(
     tab=tabfile.Tabfile,
+    tab_noheaders=tabfile.NoHeaderTab,
     fasta=fasta.Fastafile,
     relaxed_phylip=phylip.RelPhylipFile,
     fasta_hapview=fasta.HapviewFastafile,

--- a/lib/tabfile.py
+++ b/lib/tabfile.py
@@ -74,3 +74,68 @@ class Tabfile:
 
         # return the list of fields and the generator closure
         return fields, record_generator
+
+
+class NoHeaderTab:
+    """Class for reading and writing tab-separated files without headers with genetic information"""
+
+    dna_characters = set("ATGCRYMKSWBDHVNUatgcrymkswbdhvnu-?")
+
+    @staticmethod
+    def is_sequence(s: str) -> bool:
+        return all(map(lambda c: c in NoHeaderTab.dna_characters, s))
+
+    @staticmethod
+    def write(file: TextIO, fields: List[str]) -> Generator:
+        """
+        the writer method for 'tab-no headers' format
+        """
+
+        while True:
+            # receive a record
+            try:
+                record = yield
+            except GeneratorExit:
+                break
+
+            # collect record fields in a list and join them with tabs
+            file.writelines('\t'.join([record[field]
+                                       for field in fields]) + '\n')
+
+    @staticmethod
+    def read(file: TextIO) -> Tuple[List[str], Callable[[], Iterator[Record]]]:
+        """
+        the reader method for 'tab-no headers' format
+        """
+        # always the same heading
+        fields = ['seqid', 'sequence']
+
+        # closure that will iterate over the subsequent lines and yield the records
+
+        def record_generator() -> Iterator[Record]:
+            sequence_index = -1
+            first_line = True
+
+            for line in file:
+                line = line.rstrip('\n')
+                # skip blank lines
+                if line.isspace() or line == "":
+                    continue
+                # split line into values
+                values = [value for value in line.split('\t') if value]
+
+                # Test if the first column is more probable to be a sequence
+                if first_line:
+                    if not NoHeaderTab.is_sequence(values[-1]) and NoHeaderTab.is_sequence(values[0]):
+                        sequence_index = 0
+                        warnings.warn(
+                            "The last column contains non-standard DNA characters. The first column is assumed to be the sequence column")
+                    first_line = False
+
+                sequence = values.pop(sequence_index)
+                seqid = "_".join(sanitize(value) for value in values)
+
+                yield Record(seqid=seqid, sequence=sequence)
+
+        # return the list of fields and the generator closure
+        return fields, record_generator


### PR DESCRIPTION
This format will analyze the first line to decide whether the sequences are in the last or the first column.

Then it will output the last (or, respectively, the first) non-empty value in each line as the sequence and concatenate the rest into the seqid.

I decided not to allow middle columns to be the sequence column, because rejecting the empty values should be enough to deal with superfluous tabs and having having a fixed index for the sequence column might not interact correctly with variable number of columns.

Closes #26