### PR TITLE
Add resource support for Python 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ long_description = (here / 'README.md').read_text(encoding='utf-8')
 setup(
     name='DNAconvert',
 
-    version='0.1.0',
+    version='0.1.dev1',
 
     description='Converts between genetic formats',
 
@@ -39,6 +39,7 @@ setup(
         # that you indicate you support Python 3. These classifiers are *not*
         # checked by 'pip install'. See instead 'python_requires' below.
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3 :: Only',
     ],
@@ -51,7 +52,7 @@ setup(
         where='src',
     ),
 
-    python_requires='>=3.9, <4',
+    python_requires='>=3.8, <4',
 
     install_requires=[
         'python-nexus'

--- a/src/itaxotools/DNAconvert/library/resources.py
+++ b/src/itaxotools/DNAconvert/library/resources.py
@@ -1,9 +1,49 @@
 #!/usr/bin/env python3
 
 from typing import Any
-import importlib.resources
+from pathlib import Path
+import sys
+import os
 
-_resource_path = importlib.resources.files('itaxotools.DNAconvert') / "resources"
+
+def package_path_pyinstaller(package: Any) -> Path:
+    if isinstance(package, str):
+        parts = package.split('.')
+    elif isinstance(package, type(sys)):
+        parts = package.__name__.split('.')
+    else:
+        return None
+    path = Path(sys._MEIPASS)
+    for part in parts:
+        path /= part
+    return path
+
+
+def package_path_file(package: Any) -> Path:
+    if isinstance(package, str):
+        file = sys.modules[package].__file__
+    elif isinstance(package, type(sys)):
+        file = package.__file__
+    else:
+        return None
+    path = Path(os.path.dirname(file))
+    return path
+
+
+def package_path_importlib(package: Any) -> Path:
+    return importlib.resources.files(package)
+
+
+try:
+    import importlib.resources.files
+    package_path = package_path_importlib
+except ModuleNotFoundError:
+    if hasattr(sys, '_MEIPASS'):
+        package_path = package_path_pyinstaller
+    else:
+        package_path = package_path_file
+
+_resource_path = package_path('itaxotools.DNAconvert') / 'resources'
 
 
 def get_resource(path: Any) -> str:


### PR DESCRIPTION
If importlib.resources.files is not available, then try getting resources from _MEIPASS and __path__.