### PR TITLE
A checkbox to preserve special characters in sequence names

### DIFF
--- a/docs/ADDING_FORMATS.md
+++ b/docs/ADDING_FORMATS.md
@@ -22,6 +22,26 @@ The `read` method receives an input file `file`. It should return a list of fiel
 yield one-by-one objects of class `Record`, which together contain all the relevant information in the file. Each `Record` must contain at
 least all the fields named in the list. Can raise `ValueError`, if the file cannot be parsed.
 
+### Accessing options
+It's possible for the methods of format classes to access options set by the user.
+
+For the `write` method to access the options add `write_takes_kwargs` attribute and change the signature of the `write` method as follows:
+```python
+write_takes_kwargs = True
+@staticmethod
+def write(file, fields, **options)
+```
+
+For the `read` method to access the options add `read_takes_kwargs` attribute and change the signature of the `write` method as follows:
+```python
+read_takes_kwargs = True
+@staticmethod
+def read(file, **options)
+```
+
+`options` is a dictionary of booleans. Currently the only relevant options is `options.preserve_special`. If it's set, special characters
+in sequence names should be left unchanged.
+
 ## Registering the format
 In the file `lib\formats.py`
 1) Import the module

--- a/src/itaxotools/DNAconvert/DNAconvert.py
+++ b/src/itaxotools/DNAconvert/DNAconvert.py
@@ -326,6 +326,7 @@ def launch_gui() -> None:
             allow_empty_sequences=allow_empty_sequences.get(),
             automatic_renaming=automatic_renaming.get(),
             preserve_spaces=preserve_spaces.get(),
+            preserve_special=preserve_special.get(),
         )
         output_box.text.delete("1.0", "end")
         output_box.text.insert("1.0", output_data.getvalue())
@@ -353,6 +354,7 @@ def launch_gui() -> None:
                         allow_empty_sequences=allow_empty_sequences.get(),
                         automatic_renaming=automatic_renaming.get(),
                         preserve_spaces=preserve_spaces.get(),
+                        preserve_special=preserve_special.get(),
                     )
                 # display the warnings generated during the conversion
                 for w in warns:
@@ -405,6 +407,14 @@ def launch_gui() -> None:
         middle_frame, text="Preserve spaces in sequences", variable=preserve_spaces
     )
 
+    # checkbox to preserve special characters in sequence names (i.e. not "sanitize")
+    preserve_special = tk.BooleanVar()
+    preserve_special_chk = ttk.Checkbutton(
+        middle_frame,
+        text="Preserve special characters in sequence names",
+        variable=preserve_special,
+    )
+
     # place input widget group
     infile_lbl.grid(column=0, row=0, sticky=tk.W)
     infile_entry.grid(column=0, row=1, sticky=tk.W)
@@ -428,6 +438,7 @@ def launch_gui() -> None:
     automatic_renaming_chk.grid(column=0, row=0, sticky="n")
     dar_lbl.grid(column=1, row=0)
     preserve_spaces_chk.grid(column=0, row=4, sticky="w")
+    preserve_special_chk.grid(column=0, row=5, sticky="w")
 
     # place a separator above boxes
     ttk.Separator(root).grid(column=0, row=3, sticky="nsew", ipady=10)

--- a/src/itaxotools/DNAconvert/DNAconvert.py
+++ b/src/itaxotools/DNAconvert/DNAconvert.py
@@ -83,7 +83,10 @@ def convertDNA(
         return
 
     # initialize reading the file
-    fields, records = informat.read(infile)
+    if hasattr(informat, "read_takes_kwargs"):
+        fields, records = informat.read(infile, **options)
+    else:
+        fields, records = informat.read(infile)
 
     # start the writer
     if hasattr(outformat, "write_takes_kwargs"):

--- a/src/itaxotools/DNAconvert/DNAconvert.py
+++ b/src/itaxotools/DNAconvert/DNAconvert.py
@@ -86,7 +86,10 @@ def convertDNA(
     fields, records = informat.read(infile)
 
     # start the writer
-    writer = outformat.write(outfile, fields)
+    if hasattr(outformat, "write_takes_kwargs"):
+        writer = outformat.write(outfile, fields, **options)
+    else:
+        writer = outformat.write(outfile, fields)
     next(writer)
 
     # keep track of the number of skipped records

--- a/src/itaxotools/DNAconvert/library/fasta.py
+++ b/src/itaxotools/DNAconvert/library/fasta.py
@@ -39,11 +39,15 @@ def split_file(file: TextIO) -> Iterator[List[str]]:
 class Fastafile:
     """Class for standard FASTA files"""
 
+    write_takes_kwargs = True
+
     @staticmethod
-    def write(file: TextIO, fields: List[str]) -> Generator:
+    def write(file: TextIO, fields: List[str], **options: bool) -> Generator:
         """FASTA writer method"""
         # the standard NameAssembler
-        name_assembler = NameAssembler(fields)
+        name_assembler = NameAssembler(
+            fields, preserve_special=options.preserve_special
+        )
 
         # the writing loop
         while True:
@@ -78,11 +82,15 @@ class Fastafile:
 class FastafileNoGaps:
     """Class for standard FASTA files without gaps"""
 
+    write_takes_kwargs = True
+
     @staticmethod
-    def write(file: TextIO, fields: List[str]) -> Generator:
+    def write(file: TextIO, fields: List[str], **options: bool) -> Generator:
         """FASTA no gaps writer method"""
         # the standard NameAssembler
-        name_assembler = NameAssembler(fields)
+        name_assembler = NameAssembler(
+            fields, preserve_special=options.preserve_special
+        )
 
         # the writing loop
         while True:
@@ -314,7 +322,8 @@ class NameAssemblerGB(NameAssembler):
     It gives the higher priority to copying the seqid. Otherwise it is assembled from the organism and specimen_voucher field
     """
 
-    def __init__(self, fields: List[str]):
+    def __init__(self, fields: List[str], preserve_special: bool):
+        self.preserve_special = preserve_special
         if "seqid" in fields:
             self.name = self._simple_name
         else:
@@ -460,8 +469,10 @@ class GenbankFastaFile:
 
         return GenbankFastaFile.genbankfields, record_generator
 
+    write_takes_kwargs = True
+
     @staticmethod
-    def write(file: TextIO, fields: List[str]) -> Generator:
+    def write(file: TextIO, fields: List[str], **options: bool) -> Generator:
         """Genbank FASTA writer method"""
         # discard the invalid fields
         fields = [
@@ -490,7 +501,9 @@ class GenbankFastaFile:
         no_dashes = True
 
         # creates seqid for Genbank FASTA
-        name_assembler = NameAssemblerGB(fields)
+        name_assembler = NameAssemblerGB(
+            fields, preserve_special=options.preserve_special
+        )
         # makes the seqid unique within 25 characters
         unicifier = Unicifier(25)
 
@@ -536,14 +549,16 @@ class GenbankFastaFile:
 class MolDFastaFile:
     """class for MolD FASTA format"""
 
-    write_take_kwargs = True
+    write_takes_kwargs = True
 
     @staticmethod
     def write(file: TextIO, fields: List[str], **options) -> Generator:
         """MolD writer method"""
 
         # assemble the name from fields if 'specimen_voucher' or 'isolate' is missing
-        name_assembler = NameAssembler(fields, abbreviate_species=True)
+        name_assembler = NameAssembler(
+            fields, abbreviate_species=True, preserve_special=options.preserve_special
+        )
         unicifier = Unicifier()
 
         # the writing loop
@@ -617,11 +632,15 @@ class MolDFastaFile:
 class AliFile:
     """Class for Ali files"""
 
+    write_takes_kwargs = True
+
     @staticmethod
-    def write(file: TextIO, fields: List[str]) -> Generator:
+    def write(file: TextIO, fields: List[str], **options: bool) -> Generator:
         """Ali writer method"""
         # the standard NameAssembler
-        name_assembler = NameAssembler(fields)
+        name_assembler = NameAssembler(
+            fields, preserve_special=options.preserve_special
+        )
 
         # Ali needs two empty lines with a hashtag
         print("#", file=file)

--- a/src/itaxotools/DNAconvert/library/nexml.py
+++ b/src/itaxotools/DNAconvert/library/nexml.py
@@ -11,11 +11,15 @@ from .utils import NameAssembler
 class NeXMLFile:
     """Class for NeXML files"""
 
+    write_takes_kwargs = True
+
     @staticmethod
-    def write(file: TextIO, fields: List[str]) -> Generator:
+    def write(file: TextIO, fields: List[str], **options: bool) -> Generator:
         """NeXML writer method"""
 
-        name_assembler = NameAssembler(fields)
+        name_assembler = NameAssembler(
+            fields, preserve_special=options.preserve_special
+        )
         sequence_dict: Dict[str, str] = {}
 
         while True:

--- a/src/itaxotools/DNAconvert/library/phylip.py
+++ b/src/itaxotools/DNAconvert/library/phylip.py
@@ -8,13 +8,14 @@ class RelPhylipFile:
     """
     class for the relaxed Phylip format
     """
+
     @staticmethod
     def read(file: TextIO) -> Tuple[List[str], Callable[[], Iterator[Record]]]:
         """
         the reader method for the relaxed Phylip format
         """
         # Phylip always have the same fields
-        fields = ['seqid', 'sequence']
+        fields = ["seqid", "sequence"]
 
         def record_generator() -> Iterator[Record]:
             # skip the first line
@@ -28,10 +29,13 @@ class RelPhylipFile:
                 name, _, sequence = line.partition(" ")
                 # return the record
                 yield Record(seqid=name, sequence=sequence)
+
         return fields, record_generator
 
+    write_takes_kwargs = True
+
     @staticmethod
-    def write(file: TextIO, fields: List[str]) -> Generator:
+    def write(file: TextIO, fields: List[str], **options: bool) -> Generator:
         """
         the writer method for the relaxed Phylip format
         """
@@ -53,28 +57,30 @@ class RelPhylipFile:
         # formats all the sequences to the same maximum length
         aligner = dna_aligner(max_length, min_length)
         # generate the seqid from the fields
-        name_assembler = NameAssembler(fields)
+        name_assembler = NameAssembler(
+            fields, preserve_special=options.preserve_special
+        )
 
         # print the relaxed Phylip heading
         print(len(records), max_length, file=file)
 
         # print the records
         for record in records:
-            print(name_assembler.name(record), aligner(
-                record['sequence']), file=file)
+            print(name_assembler.name(record), aligner(record["sequence"]), file=file)
 
 
 class PhylipFile:
     """
     class for the Phylip format
     """
+
     @staticmethod
     def read(file: TextIO) -> Tuple[List[str], Callable[[], Iterator[Record]]]:
         """
         the reader method for the Phylip format
         """
         # Phylip always have the same fields
-        fields = ['seqid', 'sequence']
+        fields = ["seqid", "sequence"]
 
         def record_generator() -> Iterator[Record]:
             # skip the first line
@@ -89,10 +95,13 @@ class PhylipFile:
                 # everything else in the sequence
                 sequence = line[10:]
                 yield Record(seqid=name, sequence=sequence)
+
         return fields, record_generator
 
+    write_takes_kwargs = True
+
     @staticmethod
-    def write(file: TextIO, fields: List[str]) -> Generator:
+    def write(file: TextIO, fields: List[str], **options: bool) -> Generator:
         """
         the writer method for the Phylip format
         """
@@ -114,7 +123,9 @@ class PhylipFile:
         # formats all the sequences to the same maximum length
         aligner = dna_aligner(max_length, min_length)
         # generate the seqid from the fields
-        name_assembler = NameAssembler(fields, abbreviate_species=True)
+        name_assembler = NameAssembler(
+            fields, abbreviate_species=True, preserve_special=options.preserve_special
+        )
         # makes seqid unique within 10 characters
         unicifier = Unicifier(10)
 
@@ -123,5 +134,9 @@ class PhylipFile:
 
         # write the records
         for record in records:
-            print(unicifier.unique(name_assembler.name(record)),
-                  aligner(record['sequence']), sep=" ", file=file)
+            print(
+                unicifier.unique(name_assembler.name(record)),
+                aligner(record["sequence"]),
+                sep=" ",
+                file=file,
+            )

--- a/src/itaxotools/DNAconvert/library/tabfile.py
+++ b/src/itaxotools/DNAconvert/library/tabfile.py
@@ -11,11 +11,11 @@ class Tabfile:
         """
         the writer method for tab format
         """
-        if 'seqid' not in fields:
+        if "seqid" not in fields:
             raise ValueError("Tab format expects a 'seqid'")
 
         # write the heading
-        file.write('\t'.join(fields) + '\n')
+        file.write("\t".join(fields) + "\n")
 
         while True:
             # receive a record
@@ -25,11 +25,10 @@ class Tabfile:
                 break
             # enforce name uniqueness
             unicifier = Unicifier()
-            record['seqid'] = unicifier.unique(record['seqid'])
+            record["seqid"] = unicifier.unique(record["seqid"])
 
             # collect record fields in a list and join them with tabs
-            file.writelines('\t'.join([record[field]
-                                       for field in fields]) + '\n')
+            file.writelines("\t".join([record[field] for field in fields]) + "\n")
 
     @staticmethod
     def read(file: TextIO) -> Tuple[List[str], Callable[[], Iterator[Record]]]:
@@ -37,38 +36,44 @@ class Tabfile:
         the reader method for tab format
         """
         # read the heading for the list of fields
-        fields = file.readline().rstrip('\n').split('\t')
+        fields = file.readline().rstrip("\n").split("\t")
         fields = list(map(str.casefold, fields))
-        if 'seqid' not in fields and len(fields) >= 2:
+        if "seqid" not in fields and len(fields) >= 2:
             warnings.warn(
-                "The column 'seqid' is missing. Conversion will proceed, but please check the converted file for correctness.")
-        if 'sequence' not in fields:
-            sequence_candidates = [i for i, field in enumerate(
-                fields) if 'sequence' in field]
+                "The column 'seqid' is missing. Conversion will proceed, but please check the converted file for correctness."
+            )
+        if "sequence" not in fields:
+            sequence_candidates = [
+                i for i, field in enumerate(fields) if "sequence" in field
+            ]
             if len(sequence_candidates) == 1:
-                warnings.warn("The column 'sequence' is missing, but another column header containing the same term was found and is interpreted as containing the sequences. Conversion will proceed, but please check the converted file for correctness")
+                warnings.warn(
+                    "The column 'sequence' is missing, but another column header containing the same term was found and is interpreted as containing the sequences. Conversion will proceed, but please check the converted file for correctness"
+                )
                 i = sequence_candidates[0]
-                fields[i] = 'sequence'
+                fields[i] = "sequence"
             elif len(sequence_candidates) > 1:
                 i = sequence_candidates[0]
                 warnings.warn(
-                    f"The column 'sequence' is missing, the column '{fields[i]}' is interpreted as containing the sequences. Conversion will proceed, but please check the converted file for correctness")
-                fields[i] = 'sequence'
+                    f"The column 'sequence' is missing, the column '{fields[i]}' is interpreted as containing the sequences. Conversion will proceed, but please check the converted file for correctness"
+                )
+                fields[i] = "sequence"
             else:
                 warnings.warn(
-                    f"The column 'sequence' is missing, the last column '{fields[-1]}' is interpreted as containing the sequences. Conversion will proceed, but please check the converted file for correctness")
-                fields[-1] = 'sequence'
+                    f"The column 'sequence' is missing, the last column '{fields[-1]}' is interpreted as containing the sequences. Conversion will proceed, but please check the converted file for correctness"
+                )
+                fields[-1] = "sequence"
 
         # closure that will iterate over the subsequent lines and yield the records
 
         def record_generator() -> Iterator[Record]:
             for line in file:
-                line = line.rstrip('\n')
+                line = line.rstrip("\n")
                 # skip blank lines
                 if line.isspace() or line == "":
                     continue
                 # split line into values
-                values = line.split('\t')
+                values = line.split("\t")
                 # pair them with fiels and send
                 yield Record(**{field: value for field, value in zip(fields, values)})
 
@@ -80,6 +85,7 @@ class NoHeaderTab:
     """Class for reading and writing tab-separated files without headers with genetic information"""
 
     dna_characters = set("ATGCRYMKSWBDHVNUatgcrymkswbdhvnu-?")
+    read_take_kwargs = True
 
     @staticmethod
     def is_sequence(s: str) -> bool:
@@ -99,16 +105,17 @@ class NoHeaderTab:
                 break
 
             # collect record fields in a list and join them with tabs
-            file.writelines('\t'.join([record[field]
-                                       for field in fields]) + '\n')
+            file.writelines("\t".join([record[field] for field in fields]) + "\n")
 
     @staticmethod
-    def read(file: TextIO) -> Tuple[List[str], Callable[[], Iterator[Record]]]:
+    def read(
+        file: TextIO, **options: bool
+    ) -> Tuple[List[str], Callable[[], Iterator[Record]]]:
         """
         the reader method for 'tab-no headers' format
         """
         # always the same heading
-        fields = ['seqid', 'sequence']
+        fields = ["seqid", "sequence"]
 
         # closure that will iterate over the subsequent lines and yield the records
 
@@ -117,23 +124,29 @@ class NoHeaderTab:
             first_line = True
 
             for line in file:
-                line = line.rstrip('\n')
+                line = line.rstrip("\n")
                 # skip blank lines
                 if line.isspace() or line == "":
                     continue
                 # split line into values
-                values = [value for value in line.split('\t') if value]
+                values = [value for value in line.split("\t") if value]
 
                 # Test if the first column is more probable to be a sequence
                 if first_line:
-                    if not NoHeaderTab.is_sequence(values[-1]) and NoHeaderTab.is_sequence(values[0]):
+                    if not NoHeaderTab.is_sequence(
+                        values[-1]
+                    ) and NoHeaderTab.is_sequence(values[0]):
                         sequence_index = 0
                         warnings.warn(
-                            "The last column contains non-standard DNA characters. The first column is assumed to be the sequence column")
+                            "The last column contains non-standard DNA characters. The first column is assumed to be the sequence column"
+                        )
                     first_line = False
 
                 sequence = values.pop(sequence_index)
-                seqid = "_".join(sanitize(value) for value in values)
+                if options.preserve_special:
+                    seqid = "_".join(value for value in values)
+                else:
+                    seqid = "_".join(sanitize(value) for value in values)
 
                 yield Record(seqid=seqid, sequence=sequence)
 

--- a/src/itaxotools/DNAconvert/library/tabfile.py
+++ b/src/itaxotools/DNAconvert/library/tabfile.py
@@ -85,7 +85,7 @@ class NoHeaderTab:
     """Class for reading and writing tab-separated files without headers with genetic information"""
 
     dna_characters = set("ATGCRYMKSWBDHVNUatgcrymkswbdhvnu-?")
-    read_take_kwargs = True
+    read_takes_kwargs = True
 
     @staticmethod
     def is_sequence(s: str) -> bool:

--- a/src/itaxotools/DNAconvert/library/utils.py
+++ b/src/itaxotools/DNAconvert/library/utils.py
@@ -89,7 +89,10 @@ class NameAssembler:
 
     def _simple_name(self, record: Record) -> str:
         """used when there no information fields"""
-        return sanitize(record["seqid"])
+        if self.preserve_special:
+            return record["seqid"]
+        else:
+            return sanitize(record["seqid"])
 
     def _complex_name(self, record: Record) -> str:
         """used when information fields (all except 'seqid' and 'sequence') are present
@@ -99,12 +102,22 @@ class NameAssembler:
         parts = [record[field] for field in self._fields if record[field] != ""]
         if self.abbreviate_species and self._fields[0] == "species":
             parts[0] = NameAssembler._species_abbr(parts[0])
-        return "_".join(map(sanitize, parts))
+        if self.preserve_special:
+            return "_".join(parts)
+        else:
+            return "_".join(map(sanitize, parts))
 
-    def __init__(self, fields: List[str], *, abbreviate_species: bool = False):
+    def __init__(
+        self,
+        fields: List[str],
+        *,
+        abbreviate_species: bool = False,
+        preserve_special: bool,
+    ):
         # copy the fields to not mutate the original
         fields = fields.copy()
         self.abbreviate_species = abbreviate_species
+        self.preserve_special = preserve_special
         try:
             # seqid should not be used for the name generation
             fields.remove("seqid")


### PR DESCRIPTION
Inserts a checkbox "Preserve special characters in sequence names" in the GUI for the issue #55. When this checkbox is set, special characters in the names of the sequences are preserved. (i.e. the  "sanitization" is disabled.)

I feel that this solution is not completely satisfactory, so I would like to records what I did.

The best solution would be to modify `read` and `write` methods of every formats, so that the options from the GUI can be passed. However, if I would do it by hand for every format, I would probably do a lot of mistakes. So I only modified the formats that are relevant to the option being implemented. To indicate that options can be passed to the `read` or `write` method of the format, I added attributes `read_takes_kwargs` and `write_takes_kwargs` respectively. The presence of these attributes is checked in the `convertDNA` function using the built-in `hasattr` function.